### PR TITLE
Expose get_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ PASSWORD = os.environ['FELLOW_PASSWORD']
 # Create an instance
 aiden = FellowAiden(EMAIL, PASSWORD)
 
+# Get device settings
+aiden.get_settings()
+
 # Get display name of brewer
 aiden.get_display_name()
 

--- a/fellow_aiden/__init__.py
+++ b/fellow_aiden/__init__.py
@@ -114,6 +114,9 @@ class FellowAiden:
         
     def get_display_name(self):
         return self._device_config.get('displayName', None)
+
+    def get_settings(self):
+        return self._log.info(self._device_config)
         
     def get_profiles(self):
         return self._profiles


### PR DESCRIPTION
I feel like device settings should be exposed more, as that is some of the most useful info accessible throughout the API.