### PR TITLE
Downgrade to Pydantic 2.10.4 to ensure HA compability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ annotated-types==0.7.0
 certifi==2024.12.14
 charset-normalizer==3.4.1
 idna==3.10
-pydantic==2.10.5
+pydantic==2.10.4
 pydantic_core==2.27.2
 requests==2.32.3
 setuptools==75.1.0


### PR DESCRIPTION
I'm building a Home Assistant integration based on this library and have got it working pretty well already, but there's one major stumbling block. [HA is pinning Pydantic 2.10.4](https://github.com/home-assistant/core/blob/d7ec99de7dcc649291c50a25e692183419797e2b/homeassistant/package_constraints.txt#L131), this library is pinning 2.10.5.

I got around it by modifying this library and including it locally in the integration, but that's obviously a bad solution. I'd much rather be able to just import it properly. From what I could gather Pydantic 2.10.5 doesn't offer anything relevant over 2.10.4 for our use case:
https://github.com/pydantic/pydantic/releases/tag/v2.10.5